### PR TITLE
Fix #211 for OpenRC

### DIFF
--- a/41_snapshots-btrfs
+++ b/41_snapshots-btrfs
@@ -42,14 +42,6 @@ grub_btrfs_config="${sysconfdir}/default/grub-btrfs/config"
 [[ -f "$grub_btrfs_config" ]] && . "$grub_btrfs_config"
 [[ -f "${sysconfdir}/default/grub" ]] && . "${sysconfdir}/default/grub"
 
-## Exit the script, if:
-[[ "${GRUB_BTRFS_DISABLE,,}" == "true" ]] && exit 0 # Disable Grub-btrfs is set to true (default=false)
-if ! type btrfs >/dev/null 2>&1; then exit 0; fi # btrfs-progs isn't installed
-[[ -f "${GRUB_BTRFS_MKCONFIG_LIB:-/usr/share/grub/grub-mkconfig_lib}" ]] && . "${GRUB_BTRFS_MKCONFIG_LIB:-/usr/share/grub/grub-mkconfig_lib}" || exit 0 # grub-mkconfig_lib couldn't be found
-# Root filesystem isn't btrfs
-root_fs=$(${grub_probe} --target="fs" / 2>/dev/null)
-[[ "$root_fs" != "btrfs" ]] && exit 0
-
 ## Error Handling
 print_error()
 {
@@ -58,6 +50,14 @@ print_error()
     printf "%s\n" "${err_msg}" "${bug_report}" >&2 ;
     exit 0
 }
+
+## Exit the script, if:
+[[ "${GRUB_BTRFS_DISABLE,,}" == "true" ]] && print_error "GRUB_BTRFS_DISABLE is set to true (default=false)"
+if ! type btrfs >/dev/null 2>&1; then print_error "btrfs-progs isn't installed"; fi
+[[ -f "${GRUB_BTRFS_MKCONFIG_LIB:-/usr/share/grub/grub-mkconfig_lib}" ]] && . "${GRUB_BTRFS_MKCONFIG_LIB:-/usr/share/grub/grub-mkconfig_lib}" || print_error "grub-mkconfig_lib couldn't be found"
+root_fs=$(${grub_probe} --target="fs" / 2>/dev/null)
+[[ "$root_fs" != "btrfs" ]] && print_error "Root filesystem isn't btrfs"
+
 
 printf "Detecting snapshots ...\n" >&2 ;
 

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,7 @@ uninstall:
 help:
 	@echo
 	@echo "Usage: $(MAKE) [ <parameter>=<value> ... ] [ <action> ]"
+	@echo "Example: $(MAKE) OPENRC=true SYSTEMD=false install"
 	@echo
 	@echo "  actions: install"
 	@echo "           uninstall"

--- a/README.md
+++ b/README.md
@@ -3,14 +3,9 @@
 
 ## grub-btrfs 
 
-[![GitHub release](https://img.shields.io/github/release/Antynea/grub-btrfs.svg)](https://github.com/Antynea/grub-btrfs/releases)
-![](https://img.shields.io/github/license/Antynea/grub-btrfs.svg)
-
-## grub-btrfs 
-
-##### BTC donation address: `1Lbvz244WA8xbpHek9W2Y12cakM6rDe5Rt`
+* BTC donation address: `1Lbvz244WA8xbpHek9W2Y12cakM6rDe5Rt`
 - - -
-### Description:
+### Description
 Improves grub by adding "btrfs snapshots" to the grub menu.
 
 You can boot your system on a "snapshot" from the grub menu.  
@@ -35,7 +30,7 @@ Refer to the [documentation](https://github.com/Antynea/grub-btrfs/blob/master/i
 * Automatically generate `grub.cfg` if you use the provided systemd service.
 
 - - -
-### Installation:
+### Installation
 #### Arch Linux
 The package is available in the community repository [grub-btrfs](https://archlinux.org/packages/community/any/grub-btrfs/)
 ```
@@ -50,13 +45,11 @@ emerge -av app-eselect/eselect-repository
 eselect repository enable guru 
 emerge --sync 
 ```
-
-
-Now merge grub-btrfs via 
-`emerge app-backup/grub-btrfs`
-
 If you are using SystemD on Gentoo, make sure the USE-Flag `systemD` is set. (Either globally in make.conf or in package.use for the package app-backup/grub-btrfs)
 Without systemD USE-Flag the OpenRC-Daemon of grub-btrfs will be installed.
+
+Emerge grub-btrfs via 
+`emerge app-backup/grub-btrfs`
 
 #### Kali Linux
 [grub-btrfs](http://pkg.kali.org/pkg/grub-btrfs) is available in the Kali Linux repository and can be installed with:  
@@ -81,29 +74,38 @@ On **Arch Linux** or **Gentoo** use `grub-mkconfig -o /boot/grub/grub.cfg`.
 On **Fedora** use `grub2-mkconfig -o /boot/grub2/grub.cfg`  
 On **Debian-like** distribution `update-grub` is an alias to `grub-mkconfig ...`
 - - -
-### Customization:
-
+### Customization
 You have the possibility to modify many parameters in `/etc/default/grub-btrfs/config`.  
 See [config file](https://github.com/Antynea/grub-btrfs/blob/master/config) for more information.
 
+#### Warning:
+by default, `grub-mkconfig` command is used.  
+Might be `grub2-mkconfig` on some systems (Fedora ...).   
+Edit `GRUB_BTRFS_MKCONFIG` variable in `/etc/default/grub-btrfs/config` file to reflect this.
 - - -
-### Automatically update grub upon snapshot:
+### SystemD service
+#### Automatically update grub upon snapshot
 To automatically regenerate `grub-btrfs.cfg` when a modification appears in the `/.snapshots` mount point, run
-```bash
+```
 systemctl enable grub-btrfs.path
 systemctl start grub-btrfs.path  # In case the mount point is available already
 ```
 Monitoring starts automatically when the mount point becomes available.
     
-#### Snapshots not in `/.snapshots`
+##### Snapshots not in `/.snapshots`
 To modify `grub-btrfs.path` run
-```bash
+```
 systemctl edit --full grub-btrfs.path
 systemctl reenable grub-btrfs.path
 ```
 To find out the name of the `.mount` unit use `systemctl list-units -t mount`.
 
+#### Automatically update grub upon restart/ boot:
+[Look at this comment](https://github.com/Antynea/grub-btrfs/issues/138#issuecomment-766918328)  
+Currently not implemented
+
 **Timeshift**
+
 1. Run `systemctl edit --full grub-btrfs.path`
 1. Replace the whole block by:
 ```
@@ -128,47 +130,52 @@ Note:
 You can view your change to `systemctl cat grub-btrfs.path`.
 To revert change use `systemctl revert grub-btrfs.path`.
 
-----
-### Automatically update grub upon restart/boot:
-[Look at this comment](https://github.com/Antynea/grub-btrfs/issues/138#issuecomment-766918328)  
-Currently not implemented
+Note: If you are using timeshift version v22.06 or newer, snapshots are now saved in the direcory `/run/timeshift/$PIDofthecurrentlyrunnigtimeshift/backup/timeshift-btrfs` by Timeshift. The PID is changing everytime you open Timeshift. This can not be changed, but when the mount `/run/timeshift/backup/` is created in `/etc/fstab` timeshift will use that. For further information on this workaround see [Lorenzo Bettinis blog](https://www.lorenzobettini.it/2022/07/timeshift-and-grub-btrfs-in-linux-arch/).
 
 ##
-#### OpenRC
-1. If you would like grub-btrfs menu to automatically update when a snapshot is created or deleted:
-* If you are using Timeshift, newer versions of it mount their snapshots to `/run/timeshift/$pidofthecurrentlyrunnigtimeshift/backup/timeshift-btrfs`. The OpenRC-Daemon can automatically take care of the detection of the correct PID and directory if you set the variable `timeshift_auto` to `true` in `etc/conf.d/grub-btrfsd`. In this case the variable `snapshots` has no influence.
-* If you don't want to use `timeshift_auto`, set the variable `snapshots` in the file `/etc/conf.d/grub-btrfsd` to the path of your snapshot directory. By default this is set to snappers default directory,  `./snapper`.
-For Timeshift keep in mind, that newer versions of Timeshift will not work with the `/run/timeshift/backup/timeshift-btrfs/snapshots` path. However there is a [workaround](https://www.lorenzobettini.it/2022/07/timeshift-and-grub-btrfs-in-linux-arch/) that works for now. 
-* Use `rc-config add grub-btrfsd default`, to start the grub-btrfsd daemon the next time the system boots. 
-	* To start `grub-btrfsd` right now, run `rc-service grub-btrfsd start`
-	* `grub-btrfsd` automatically watches the snapshot directory and updates the grub-menu when a change occurs
+### OpenRC daemon
+#### Automatically update grub upon snapshot
+If you would like grub-btrfs menu to automatically update when a snapshot is created or deleted, configure `/etc/conf.d/grub-btrfsd` and after that start the daemon.
+###### Timeshift versions >= v22.06 (default)
+This is the default setting, you don't need to change anything in `/etc/conf.d/grub-btrfsd`, keep on reading at the "How to (auto)start the daemon" heading. 
+Newer versions of Timeshift mount their snapshots to `/run/timeshift/$PIDofthecurrentlyrunnigtimeshift/backup/timeshift-btrfs`. The PID is changing everytime you close Timeshift and open it again. The OpenRC-Daemon can automatically take care of the detection of the correct PID and directory if you set the variable `timeshift_auto` to `true` in `/etc/conf.d/grub-btrfsd`. In this case the variable `snapshots` has no influence.
+###### Timeshift versions < v22.06
+If you don't want to use `timeshift_auto`, set the variable `snapshots` in the file `/etc/conf.d/grub-btrfsd` to the path of your snapshot directory. This is usually `/run/timeshift/backup/timeshift-btrfs/snapshots`. This will not work for newer Timeshift versions, however there is a [workaround](https://www.lorenzobettini.it/2022/07/timeshift-and-grub-btrfs-in-linux-arch/) that works for now. Basically you need to mount the root subvolume to `/run/timeshift/backup` by putting this line into `/etc/fstab`:
+```
+UUID=<UUID> /run/timeshift/backup       btrfs   defaults,noatime  0 0
+```
+You can get your UUID with the command `blkid`.
 
-2. If you would like grub-btrfs menu to automatically update on system restart/ shutdown:
-Just add the following script as `/etc/local.d/grub-btrfs-update.stop`
-	```bash
-	#!/bin/bash
+###### Snapper
+For snapper set `timeshift-auto=false` and `snapshots` to Snapper snapshots directory. (usually `/.snapshots`)
+##### How to (auto)start the daemon
+Use `sudo rc-config add grub-btrfsd default`, to start the grub-btrfsd daemon the next time the system boots. 
+To start `grub-btrfsd` right now, run `sudo rc-service grub-btrfsd start`.
+`grub-btrfsd` then automatically watches the snapshot directory and updates the grub-menu when a change occurs.
+When you changed a setting in `/etc/conf.d/grub-btrfd`, you have to restart the daemon with `sudo rc-service grub-btrfd restart` to make the change become effective. 
+
+#### Automatically update grub upon restart/boot:
+If you would like the grub-btrfs menu to automatically update on system restart/ shutdown, just add the following script as `/etc/local.d/grub-btrfs-update.stop`:
+```bash
+#!/usr/bin/env bash
+
+description="Update the grub btrfs snapshots menu"
+name="grub-btrfs-update"
+
+depend()
+{
+	use localmount
+}
 	
-	description="Update the grub btrfs snapshots menu"
-	name="grub-btrfs-update"
-	
-	depend()
-	{
-	  use localmount
-	}
-	
-	bash -c 'if [ -s "${GRUB_BTRFS_GRUB_DIRNAME:-/boot/grub}/grub-btrfs.cfg" ]; then /etc/grub.d/41_snapshots-btrfs; else {GRUB_BTRFS_MKCONFIG:-grub-mkconfig} -o {GRUB_BTRFS_GRUB_DIRNAME:-/boot/grub}/grub.cfg; fi' 
-	```
-	
-	Make your script executable with `chmod a+x /etc/local.d/grub-btrfs-update.stop`.
+bash -c 'if [ -s "${GRUB_BTRFS_GRUB_DIRNAME:-/boot/grub}/grub-btrfs.cfg" ]; then /etc/grub.d/41_snapshots-btrfs; else {GRUB_BTRFS_MKCONFIG:-grub-mkconfig} -o {GRUB_BTRFS_GRUB_DIRNAME:-/boot/grub}/grub.cfg; fi' 
+```
+
+Make your script executable with `chmod a+x /etc/local.d/grub-btrfs-update.stop`.
 
 * The extension ".stop" at the end of the filename indicates to locald that this script should be run at shutdown. 
  If you want to run the menu update on startup instead, rename the file to `grub-btrfs-update.start`
 * Works for snapper and timeshift
 
-##### Warning:
-by default, `grub-mkconfig` command is used.  
-Might be `grub2-mkconfig` on some systems (Fedora ...).   
-Edit `GRUB_BTRFS_MKCONFIG` variable in `/etc/default/grub-btrfs/config` file to reflect this.
 - - -
 ### Special thanks for assistance and contributions
 * [Maxim Baz](https://github.com/maximbaz)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@
 
 ## grub-btrfs 
 
-This is a version 4.xx of grub-btrfs
+[![GitHub release](https://img.shields.io/github/release/Antynea/grub-btrfs.svg)](https://github.com/Antynea/grub-btrfs/releases)
+![](https://img.shields.io/github/license/Antynea/grub-btrfs.svg)
+
+## grub-btrfs 
+
 ##### BTC donation address: `1Lbvz244WA8xbpHek9W2Y12cakM6rDe5Rt`
 - - -
 ### Description:
@@ -22,7 +26,7 @@ This project includes its own solution.
 Refer to the [documentation](https://github.com/Antynea/grub-btrfs/blob/master/initramfs/readme.md).
 
 - - -
-### What features does grub-btrfs v4.xx have?
+### What features does grub-btrfs have?
 * Automatically list snapshots existing on root partition (btrfs).
 * Automatically detect if `/boot` is in separate partition.
 * Automatically detect kernel, initramfs and intel/amd microcode in `/boot` directory on snapshots.
@@ -47,8 +51,12 @@ eselect repository enable guru
 emerge --sync 
 ```
 
+
 Now merge grub-btrfs via 
 `emerge app-backup/grub-btrfs`
+
+If you are using SystemD on Gentoo, make sure the USE-Flag `systemD` is set. (Either globally in make.conf or in package.use for the package app-backup/grub-btrfs)
+Without systemD USE-Flag the OpenRC-Daemon of grub-btrfs will be installed.
 
 #### Kali Linux
 [grub-btrfs](http://pkg.kali.org/pkg/grub-btrfs) is available in the Kali Linux repository and can be installed with:  
@@ -64,7 +72,7 @@ Booting into read-only snapshots is fully supported when choosing "btrfs" as fil
   * [btrfs-progs](https://archlinux.org/packages/core/x86_64/btrfs-progs/)
   * [grub](https://archlinux.org/packages/core/x86_64/grub/)
   * [bash >4](https://archlinux.org/packages/core/x86_64/bash/)
-  * [gawk ](https://archlinux.org/packages/core/x86_64/gawk/)
+  * [gawk](https://archlinux.org/packages/core/x86_64/gawk/)
 
 #### NOTE: All distros
 Generate your grub menu after installation for the changes to take effect.  
@@ -128,11 +136,12 @@ Currently not implemented
 ##
 #### OpenRC
 1. If you would like grub-btrfs menu to automatically update when a snapshot is created or deleted:
+* If you are using Timeshift, newer versions of it mount their snapshots to `/run/timeshift/$pidofthecurrentlyrunnigtimeshift/backup/timeshift-btrfs`. The OpenRC-Daemon can automatically take care of the detection of the correct PID and directory if you set the variable `timeshift_auto` to `true` in `etc/conf.d/grub-btrfsd`. In this case the variable `snapshots` has no influence.
+* If you don't want to use `timeshift_auto`, set the variable `snapshots` in the file `/etc/conf.d/grub-btrfsd` to the path of your snapshot directory. By default this is set to snappers default directory,  `./snapper`.
+For Timeshift keep in mind, that newer versions of Timeshift will not work with the `/run/timeshift/backup/timeshift-btrfs/snapshots` path. However there is a [workaround](https://www.lorenzobettini.it/2022/07/timeshift-and-grub-btrfs-in-linux-arch/) that works for now. 
 * Use `rc-config add grub-btrfsd default`, to start the grub-btrfsd daemon the next time the system boots. 
 	* To start `grub-btrfsd` right now, run `rc-service grub-btrfsd start`
-	* `grub-btrfsd` automatically watches the snapshot directory of timeshift (/run/timeshift/backup/timeshift-btrfs/snapshots)
-	and updates the grub-menu when a change occurs.
-* Currently untested for snapper
+	* `grub-btrfsd` automatically watches the snapshot directory and updates the grub-menu when a change occurs
 
 2. If you would like grub-btrfs menu to automatically update on system restart/ shutdown:
 Just add the following script as `/etc/local.d/grub-btrfs-update.stop`
@@ -150,7 +159,7 @@ Just add the following script as `/etc/local.d/grub-btrfs-update.stop`
 	bash -c 'if [ -s "${GRUB_BTRFS_GRUB_DIRNAME:-/boot/grub}/grub-btrfs.cfg" ]; then /etc/grub.d/41_snapshots-btrfs; else {GRUB_BTRFS_MKCONFIG:-grub-mkconfig} -o {GRUB_BTRFS_GRUB_DIRNAME:-/boot/grub}/grub.cfg; fi' 
 	```
 	
-	Make your script executeable with `chmod a+x /etc/local.d/grub-btrfs-update.stop`.
+	Make your script executable with `chmod a+x /etc/local.d/grub-btrfs-update.stop`.
 
 * The extension ".stop" at the end of the filename indicates to locald that this script should be run at shutdown. 
  If you want to run the menu update on startup instead, rename the file to `grub-btrfs-update.start`

--- a/grub-btrfs-openrc
+++ b/grub-btrfs-openrc
@@ -1,7 +1,43 @@
 #!/bin/sh
-echo $$ > /run/grub-btrfsd.pid
-snapshots="${1:-/run/timeshift/backup/timeshift-btrfs/snapshots}"
+# Copyright 2022 Pascal Jaeger
+# Distributed under the terms of the GNU General Public License v3
+# Update GRUB when new BTRFS snapshots are created.
 
-while true; do sleep 1 && inotifywait -e create -e delete "$snapshots" && sleep 5 && if [ -s "${GRUB_BTRFS_GRUB_DIRNAME:-/boot/grub}/grub-btrfs.cfg" ]; then /etc/grub.d/41_snapshots-btrfs; else ${GRUB_BTRFS_MKCONFIG:-grub-mkconfig} -o ${GRUB_BTRFS_GRUB_DIRNAME:-/boot/grub}/grub.cfg; fi  ; done
+timeshift_pid
+watchtime=0
 
+snapshots="${1}"
+timeshift_auto="${2}"
 
+if  ! [ "${#snapshots}" -gt 0 ] && ! [ ${timeshift_auto} ]; then
+    echo "Please specify the snapshots directory" >&2
+    exit 1
+fi
+if [ ${timeshift_auto} ]; then
+    watchtime=15
+else
+    watchtime=0
+fi
+
+while true; do
+    if [ ${timeshift_auto} == "true" ] && ! [ "${#timeshift_pid}" -gt 0 ] ; then
+        inotifywait -e create -e delete /run/timeshift && {
+            sleep 1
+            timeshift_pid=$(ps ax | awk '{sub(/.*\//, "", $5)} $5 ~ /timeshift/ {print $1}')
+            snapshots="/run/timeshift/${timeshift_pid}/backup/timeshift-btrfs/snapshots"
+        }
+    else
+        while [ -d "$snapshots" ]; do
+            sleep 1
+            inotifywait -e create -e delete -e unmount -t "$watchtime" "$snapshots" && {
+                sleep 5
+                if [ -s "${GRUB_BTRFS_GRUB_DIRNAME:-/boot/grub}/grub-btrfs.cfg" ]; then
+                    /etc/grub.d/41_snapshots-btrfs
+                else
+                    ${GRUB_BTRFS_MKCONFIG:-grub-mkconfig} -o ${GRUB_BTRFS_GRUB_DIRNAME:-/boot/grub}/grub.cfg
+                fi
+            }
+        done
+        timeshift_pid=""
+    fi
+done

--- a/grub-btrfsd.confd
+++ b/grub-btrfsd.confd
@@ -1,3 +1,10 @@
-# Where to locate the root snapshots
-#snapshots="/.snapshots" # Snapper in the root directory
-snapshots="/run/timeshift/backup/timeshift-btrfs/snapshots" # Timeshift
+# Copyright 2022 Pascal Jaeger
+# Distributed under the terms of the GNU General Public License v3
+
+## Where to locate the root snapshots
+snapshots="/.snapshots" # Snapper in the root directory
+#snapshots="/run/timeshift/backup/timeshift-btrfs/snapshots" # Timeshift < v22.06
+
+## Autodetect timeshift snapshot directory. If this it set to true, variable snapshots is not taken into account. Use this for Timeshift >= v22.06
+timeshift_auto=true # Timeshift >= v22.06
+#timeshift_auto=false # snapper

--- a/grub-btrfsd.initd
+++ b/grub-btrfsd.initd
@@ -1,15 +1,13 @@
 #!/sbin/openrc-run
-# Copyright 1999-2021 Gentoo Foundation
-# Distributed under the terms of the GNU General Public License v2
+# Copyright 2021 Pascal Jaeger
+# Distributed under the terms of the GNU General Public License v3
 
 name="grub-btrfs daemon"
 command="/usr/bin/grub-btrfs-openrc"
-command_args="${snapshots}"
+command_args="${snapshots} ${timeshift_auto}"
 pidfile="/run/{RC_SVCNAME}.pid"
 command_background=true
 
 depend() {
    use localmount
 }
-
-


### PR DESCRIPTION
Gentoogang strikes again!  
This fixes #211 for OpenRC. All setup is done via the config file in /etc/conf.d/grub-btrfsd.
- snapshots set the snapshot directory as you intended
- timeshift_auto can be set true or false. If true, the daemon will watch /run/timeshift for a change, and if there is one it will get the PID of timeshift and it will hook inotify to the directory /run/timeshift/$PID/backup/timeshift-btrfs/snapshots. Because it wont exit when timeshift exits and unmounts this directory while inotify is watching, the hook is only valid for 15 seconds, after that it gets the PID again and hooks to the directory again. 

I also updated the readme accordingly and I fixed the licence of the Daemon to be GPLv3, also I removed the Gentoo Foundation nonsense. Feel free to add yourself as an author if you like. 

Because of a little oopsie I did with the repo of my other PR, I included it here. It is just printing error messages when the script exits now instead of just exiting. 


